### PR TITLE
Fix "Highlight Groups" for version 2.11.465

### DIFF
--- a/src/sh/jay/xposed/whatsapp/HighlightGroups.java
+++ b/src/sh/jay/xposed/whatsapp/HighlightGroups.java
@@ -28,9 +28,9 @@ public class HighlightGroups implements IXposedHookLoadPackage {
     private static final Map<View, View> conversationRows = new HashMap<View, View>();
 
     /**
-    * This is initially called by the Xposed Framework when we register this
-    * android application as an Xposed Module.
-    */
+     * This is initially called by the Xposed Framework when we register this
+     * android application as an Xposed Module.
+     */
     public void handleLoadPackage(final LoadPackageParam lpparam) throws Throwable {
         // This method is called once per package, so we only want to apply hooks to WhatsApp.
         if (!Utils.WHATSAPP_PACKAGE_NAME.equals(lpparam.packageName)) {


### PR DESCRIPTION
There was a slight change in WA 2.11.465, as group tags now end with "@g.us_156_6.0", so now we just hope the "@g.us" is contained in the tag.
This pull request also tries to query the conversationRows map a little less (as it is somewhat performance critical).
